### PR TITLE
feat: add quarter and three-quarter star support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,71 +7,70 @@ A customizable, animated star rating component for React Native. Compatible with
 ![Demo](https://github.com/benediktviebahn/react-native-star-rating-widget/raw/master/media/demo.gif)
 
 ## Installation
+
 1. install react-native-star-rating-widget
-`npm install react-native-star-rating-widget --save` or `yarn add react-native-star-rating-widget`
+   `npm install react-native-star-rating-widget --save` or `yarn add react-native-star-rating-widget`
 2. if not already installed, add [react-native-svg](https://github.com/react-native-community/react-native-svg)
 
 ## Usage
-This package exports an 
+
+This package exports an
 
 ### Interactive `StarRating` component
+
 ```js
 import StarRating from 'react-native-star-rating-widget';
 
 const Example = () => {
   const [rating, setRating] = useState(0);
-  return (
-      <StarRating
-        rating={rating}
-        onChange={setRating}
-      />
-  );
+  return <StarRating rating={rating} onChange={setRating} />;
 };
 ```
 
 ### Non-Interactive `StarRatingDisplay` component
+
 ```js
 import { StarRatingDisplay } from 'react-native-star-rating-widget';
 
 const Example = () => {
-  return (
-      <StarRatingDisplay
-        rating={4.5}
-      />
-  );
+  return <StarRatingDisplay rating={4.5} />;
 };
 ```
 
 See [example/src](example/src) for more examples.
 
 ## Props
+
 ### `StarRating` Props
-| Name              | Type                     | Default          | Description                                           |
-| ----------------- | -----------------------  | ---------------- | ----------------------------------------------------- |
-| rating            | number                   | **REQUIRED**     | Rating Value. Should be between 0 and `maxStars`      |
-| onChange          | (rating: number) => void | **REQUIRED**     | called when rating changes                            |
-| maxStars          | number                   | 5                | number of stars                                       |
-| starSize          | number                   | 32               | star size                                             |
-| color             | string                   | "#fdd835"        | star color                                            |
-| emptyColor        | string                   | same as `color`  | empty star color                                      |
-| style             | object                   | undefined        | optional style                                        |
-| starStyle         | object                   | undefined        | optional star style                                   |
-| enableHalfStar    | boolean                  | true             | enable or disable display of half stars               |
-| enableSwiping     | boolean                  | true             | enable or disable swiping                             |
-| onRatingStart     | (rating: number) => void | undefined        | called when the interaction starts, before `onChange` |
-| onRatingEnd       | (rating: number) => void | undefined        | called when the interaction starts, after `onChange`  |
-| animationConfig   | see [AnimationConfig](#animationConfig) | see [AnimationConfig](#animationConfig) | animation configuration object |
-| StarIconComponent | (props: { index: number; size: number; color: string; type: "full" \| "half" \| "empty"; }) => JSX.Element | [StarIcon](https://github.com/bviebahn/react-native-star-rating-widget/blob/master/src/StarIcon.tsx) | Icon component                                            |
-| accessibilityLabel | string                  | star rating. %value% stars. use custom actions to set rating. | The label used on the star component |
-| accessabilityIncrementLabel | string         | increment        | The label for the increment action                    |
-| accessabilityDecrementLabel | string         | decrement        | The label for the decrement action.                   |
-| accessabilityActivateLabel  | string         | activate (default) | The label for the activate action.                  |
-| accessibilityAdjustmentLabel | string        | %value% stars    | The label that is announced after adjustment action   |
+
+| Name                         | Type                                                                                                       | Default                                                                                              | Description                                                     |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| rating                       | number                                                                                                     | **REQUIRED**                                                                                         | Rating Value. Should be between 0 and `maxStars`                |
+| onChange                     | (rating: number) => void                                                                                   | **REQUIRED**                                                                                         | called when rating changes                                      |
+| maxStars                     | number                                                                                                     | 5                                                                                                    | number of stars                                                 |
+| starSize                     | number                                                                                                     | 32                                                                                                   | star size                                                       |
+| color                        | string                                                                                                     | "#fdd835"                                                                                            | star color                                                      |
+| emptyColor                   | string                                                                                                     | same as `color`                                                                                      | empty star color                                                |
+| style                        | object                                                                                                     | undefined                                                                                            | optional style                                                  |
+| starStyle                    | object                                                                                                     | undefined                                                                                            | optional star style                                             |
+| step                         | "full" \| "half" \| "quarter"                                                                              | "half"                                                                                               | step size for rating - full stars, half stars, or quarter stars |
+| enableSwiping                | boolean                                                                                                    | true                                                                                                 | enable or disable swiping                                       |
+| onRatingStart                | (rating: number) => void                                                                                   | undefined                                                                                            | called when the interaction starts, before `onChange`           |
+| onRatingEnd                  | (rating: number) => void                                                                                   | undefined                                                                                            | called when the interaction starts, after `onChange`            |
+| animationConfig              | see [AnimationConfig](#animationConfig)                                                                    | see [AnimationConfig](#animationConfig)                                                              | animation configuration object                                  |
+| StarIconComponent            | (props: { index: number; size: number; color: string; type: "full" \| "half" \| "empty"; }) => JSX.Element | [StarIcon](https://github.com/bviebahn/react-native-star-rating-widget/blob/master/src/StarIcon.tsx) | Icon component                                                  |
+| accessibilityLabel           | string                                                                                                     | star rating. %value% stars. use custom actions to set rating.                                        | The label used on the star component                            |
+| accessabilityIncrementLabel  | string                                                                                                     | increment                                                                                            | The label for the increment action                              |
+| accessabilityDecrementLabel  | string                                                                                                     | decrement                                                                                            | The label for the decrement action.                             |
+| accessabilityActivateLabel   | string                                                                                                     | activate (default)                                                                                   | The label for the activate action.                              |
+| accessibilityAdjustmentLabel | string                                                                                                     | %value% stars                                                                                        | The label that is announced after adjustment action             |
 
 ### `StarRatingDisplay` Props
+
 The `StarRatingDisplay` component accepts mostly the same props as `StarRating` except those that are interaction related props such as `onChange`, `enableSwiping`, `onRatingStart` etc.
 
 ### AnimationConfig
+
 | Name     | Type               | Default           | Description                                |
 | -------- | ------------------ | ----------------- | ------------------------------------------ |
 | scale    | number             | 1.2               | star animation scale value                 |

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,10 +5,12 @@ import BasicExample from './BasicExample';
 import CustomIconExample from './CustomIconExample';
 import StarRatingDisplayExample from './StarRatingDisplayExample';
 import ClearOnCurrentRatingTapExample from './ClearOnCurrentRatingTapExample';
+import StepPropExample from './StepPropExample';
 
 export default function App() {
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <StepPropExample />
       <BasicExample />
       <CustomIconExample />
       <StarRatingDisplayExample />

--- a/example/src/StepPropExample.tsx
+++ b/example/src/StepPropExample.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Text, StyleSheet, View } from 'react-native';
+import StarRating from 'react-native-star-rating-widget';
+import ExampleContainer from './ExampleContainer';
+
+export default function StepPropExample() {
+  const [fullRating, setFullRating] = React.useState(3);
+  const [halfRating, setHalfRating] = React.useState(2.5);
+  const [quarterRating, setQuarterRating] = React.useState(3.75);
+
+  return (
+    <ExampleContainer title="Step Prop Examples">
+      <View style={styles.section}>
+        <Text style={styles.label}>Full Stars (step="full")</Text>
+        <StarRating rating={fullRating} onChange={setFullRating} step="full" />
+        <Text style={styles.rating}>Rating: {fullRating}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Half Stars (step="half" - default)</Text>
+        <StarRating rating={halfRating} onChange={setHalfRating} step="half" />
+        <Text style={styles.rating}>Rating: {halfRating}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.label}>Quarter Stars (step="quarter")</Text>
+        <StarRating
+          rating={quarterRating}
+          onChange={setQuarterRating}
+          step="quarter"
+        />
+        <Text style={styles.rating}>Rating: {quarterRating}</Text>
+      </View>
+    </ExampleContainer>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    alignItems: 'center',
+    marginBottom: 16,
+    width: '100%',
+  },
+  label: {
+    fontSize: 14,
+    color: '#666',
+    marginBottom: 8,
+  },
+  rating: {
+    fontSize: 12,
+    color: '#999',
+    marginTop: 4,
+  },
+});

--- a/src/StarIcon.tsx
+++ b/src/StarIcon.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import { I18nManager, ViewStyle } from 'react-native';
-import Svg, { Path, Rect } from 'react-native-svg';
+import Svg, { Path, Defs, LinearGradient, Stop } from 'react-native-svg';
 
 export type StarIconProps = {
   index: number;
   size: number;
   color: string;
-  type: 'full' | 'half' | 'empty';
+  type: 'full' | 'half' | 'quarter' | 'three-quarter' | 'empty';
+};
+
+const RTL_TRANSFORM: ViewStyle = {
+  transform: [{ rotateY: '180deg' }],
 };
 
 const StarBorder = ({ size, color }: Omit<StarIconProps, 'type'>) => (
@@ -18,40 +22,108 @@ const StarBorder = ({ size, color }: Omit<StarIconProps, 'type'>) => (
   </Svg>
 );
 
-const StarFull = ({ size, color }: Omit<StarIconProps, 'type'>) => (
-  <Svg height={size} viewBox="0 0 24 24" width={size}>
-    <Path d="M0 0h24v24H0z" fill="none" />
-    <Path d="M0 0h24v24H0z" fill="none" />
-    <Path
-      fill={color}
-      d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
-    />
-  </Svg>
-);
-
-const RTL_TRANSFORM: ViewStyle = {
-  transform: [{ rotateY: '180deg' }],
+const StarFull = ({ size, color, index }: Omit<StarIconProps, 'type'>) => {
+  const gradientId = `full-gradient-${index}`;
+  return (
+    <Svg height={size} viewBox="0 0 24 24" width={size}>
+      <Defs>
+        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="100%" stopColor={color} stopOpacity="1" />
+          <Stop offset="100%" stopColor={color} stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+      <Path
+        d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+        fill={`url(#${gradientId})`}
+        stroke={color}
+        strokeWidth="1.5"
+      />
+    </Svg>
+  );
 };
 
-const StarHalf = ({ size, color }: Omit<StarIconProps, 'type'>) => (
-  <Svg
-    height={size}
-    viewBox="0 0 24 24"
-    width={size}
-    style={I18nManager.isRTL ? RTL_TRANSFORM : undefined}
-  >
-    <Rect fill="none" height="24" width="24" x="0" />
-    <Path
-      fill={color}
-      d="M22,9.24l-7.19-0.62L12,2L9.19,8.63L2,9.24l5.46,4.73L5.82,21L12,17.27L18.18,21l-1.63-7.03L22,9.24z M12,15.4V6.1 l1.71,4.04l4.38,0.38l-3.32,2.88l1,4.28L12,15.4z"
-    />
-  </Svg>
-);
+const StarQuarter = ({ size, color, index }: Omit<StarIconProps, 'type'>) => {
+  const gradientId = `quarter-gradient-${index}`;
+  return (
+    <Svg height={size} viewBox="0 0 24 24" width={size}>
+      <Defs>
+        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="33%" stopColor={color} stopOpacity="1" />
+          <Stop offset="33%" stopColor={color} stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+      <Path
+        d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+        fill={`url(#${gradientId})`}
+        stroke={color}
+        strokeWidth="1.5"
+      />
+    </Svg>
+  );
+};
+
+const StarThreeQuarter = ({ size, color, index }: Omit<StarIconProps, 'type'>) => {
+  const gradientId = `three-quarter-gradient-${index}`;
+  return (
+    <Svg height={size} viewBox="0 0 24 24" width={size}>
+      <Defs>
+        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="66%" stopColor={color} stopOpacity="1" />
+          <Stop offset="66%" stopColor={color} stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+      <Path
+        d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+        fill={`url(#${gradientId})`}
+        stroke={color}
+        strokeWidth="1.5"
+      />
+    </Svg>
+  );
+};
+
+const StarHalf = ({ size, color, index }: Omit<StarIconProps, 'type'>) => {
+  const gradientId = `half-gradient-${index}`;
+  return (
+    <Svg
+      height={size}
+      viewBox="0 0 24 24"
+      width={size}
+      style={I18nManager.isRTL ? RTL_TRANSFORM : undefined}
+    >
+      <Defs>
+        <LinearGradient id={gradientId} x1="0" y1="0" x2="1" y2="0">
+          <Stop offset="50%" stopColor={color} stopOpacity="1" />
+          <Stop offset="50%" stopColor={color} stopOpacity="0" />
+        </LinearGradient>
+      </Defs>
+      <Path
+        d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"
+        fill={`url(#${gradientId})`}
+        stroke={color}
+        strokeWidth="1.5"
+      />
+    </Svg>
+  );
+};
+
+const getStarComponent = (type: StarIconProps['type']) => {
+  switch (type) {
+    case 'full':
+      return StarFull;
+    case 'half':
+      return StarHalf;
+    case 'quarter':
+      return StarQuarter;
+    case 'three-quarter':
+      return StarThreeQuarter;
+    default:
+      return StarBorder;
+  }
+};
 
 const StarIcon = ({ index, type, size, color }: StarIconProps) => {
-  const Component =
-    type === 'full' ? StarFull : type === 'half' ? StarHalf : StarBorder;
-
+  const Component = getStarComponent(type);
   return <Component index={index} size={size} color={color} />;
 };
 

--- a/src/StarRating.tsx
+++ b/src/StarRating.tsx
@@ -68,6 +68,13 @@ type StarRatingProps = {
   enableHalfStar?: boolean;
 
   /**
+   * Enable quarter star ratings.
+   *
+   * @default false
+   */
+  enableQuarterStar?: boolean;
+
+  /**
    * Enable swiping to rate.
    *
    * @default true
@@ -174,6 +181,7 @@ const StarRating = ({
   color = defaultColor,
   emptyColor = color,
   enableHalfStar = true,
+  enableQuarterStar = false,
   enableSwiping = true,
   onRatingStart,
   onRatingEnd,
@@ -199,15 +207,21 @@ const StarRating = ({
       if (isRTL) {
         return calculateRating(width.current - x, false);
       }
-      const newRating = Math.max(
+      const newRating = enableQuarterStar ? Math.max(
+        0,
+        Math.min(
+          Math.round((x / width.current) * maxStars * 4 + 0.2) / 4,
+          maxStars
+        )
+      ) : Math.max(
         0,
         Math.min(
           Math.round((x / width.current) * maxStars * 2 + 0.2) / 2,
           maxStars
         )
-      );
+      )
 
-      return enableHalfStar ? newRating : Math.ceil(newRating);
+      return enableHalfStar || enableQuarterStar ? newRating : Math.ceil(newRating);
     };
 
     const handleChange = (newRating: number) => {
@@ -277,8 +291,8 @@ const StarRating = ({
         )}
         accessibilityValue={{
           min: 0,
-          max: enableHalfStar ? maxStars * 2 : maxStars,
-          now: enableHalfStar ? rating * 2 : rating, // this has to be an integer
+          max: enableQuarterStar ? maxStars * 4 : enableHalfStar ? maxStars * 2 : maxStars,
+          now: enableQuarterStar ? Math.round(rating * 4) : enableHalfStar ? Math.round(rating * 2) : Math.round(rating), // this has to be an integer
         }}
         accessibilityActions={[
           { name: 'increment', label: accessabilityIncrementLabel },
@@ -329,7 +343,7 @@ const StarRating = ({
           }
         }}
       >
-        {getStars(rating, maxStars).map((starType, i) => {
+        {getStars(rating, maxStars, enableQuarterStar).map((starType, i) => {
           return (
             <AnimatedIcon
               key={i}

--- a/src/StarRating.tsx
+++ b/src/StarRating.tsx
@@ -61,18 +61,11 @@ type StarRatingProps = {
   starSize?: number;
 
   /**
-   * Enable half star ratings.
+   * Step size for the rating.
    *
-   * @default true
+   * @default 'half'
    */
-  enableHalfStar?: boolean;
-
-  /**
-   * Enable quarter star ratings.
-   *
-   * @default false
-   */
-  enableQuarterStar?: boolean;
+  step?: 'half' | 'quarter' | 'full';
 
   /**
    * Enable swiping to rate.
@@ -180,8 +173,7 @@ const StarRating = ({
   onChange,
   color = defaultColor,
   emptyColor = color,
-  enableHalfStar = true,
-  enableQuarterStar = false,
+  step = 'half',
   enableSwiping = true,
   onRatingStart,
   onRatingEnd,
@@ -196,6 +188,7 @@ const StarRating = ({
   accessabilityActivateLabel = 'activate (default)',
   accessibilityAdjustmentLabel = '%value% stars',
 }: StarRatingProps) => {
+  const multiplier = step === 'quarter' ? 4 : step === 'half' ? 2 : 1;
   const width = React.useRef<number>();
   const [isInteracting, setInteracting] = React.useState(false);
   const [stagedRating, setStagedRating] = React.useState(rating);
@@ -207,21 +200,20 @@ const StarRating = ({
       if (isRTL) {
         return calculateRating(width.current - x, false);
       }
-      const newRating = enableQuarterStar ? Math.max(
-        0,
-        Math.min(
-          Math.round((x / width.current) * maxStars * 4 + 0.2) / 4,
-          maxStars
-        )
-      ) : Math.max(
-        0,
-        Math.min(
-          Math.round((x / width.current) * maxStars * 2 + 0.2) / 2,
-          maxStars
-        )
-      )
 
-      return enableHalfStar || enableQuarterStar ? newRating : Math.ceil(newRating);
+      const newRating =
+        step !== 'full'
+          ? Math.max(
+              0,
+              Math.min(
+                Math.round((x / width.current) * maxStars * multiplier + 0.2) /
+                  multiplier,
+                maxStars
+              )
+            )
+          : Math.ceil((x / width.current) * maxStars);
+
+      return newRating;
     };
 
     const handleChange = (newRating: number) => {
@@ -266,12 +258,13 @@ const StarRating = ({
   }, [
     rating,
     maxStars,
-    enableHalfStar,
     onChange,
     enableSwiping,
     onRatingStart,
     onRatingEnd,
     animationConfig.delay,
+    step,
+    multiplier,
   ]);
 
   return (
@@ -291,8 +284,8 @@ const StarRating = ({
         )}
         accessibilityValue={{
           min: 0,
-          max: enableQuarterStar ? maxStars * 4 : enableHalfStar ? maxStars * 2 : maxStars,
-          now: enableQuarterStar ? Math.round(rating * 4) : enableHalfStar ? Math.round(rating * 2) : Math.round(rating), // this has to be an integer
+          max: maxStars * multiplier,
+          now: Math.round(rating * multiplier),
         }}
         accessibilityActions={[
           { name: 'increment', label: accessabilityIncrementLabel },
@@ -300,7 +293,8 @@ const StarRating = ({
           { name: 'activate', label: accessabilityActivateLabel },
         ]}
         onAccessibilityAction={(event: AccessibilityActionEvent) => {
-          const incrementor = enableHalfStar ? 0.5 : 1;
+          const incrementor =
+            step === 'half' ? 0.5 : step === 'quarter' ? 0.25 : 1;
           switch (event.nativeEvent.actionName) {
             case 'increment':
               if (stagedRating >= maxStars) {
@@ -343,7 +337,7 @@ const StarRating = ({
           }
         }}
       >
-        {getStars(rating, maxStars, enableQuarterStar).map((starType, i) => {
+        {getStars(rating, maxStars, step).map((starType, i) => {
           return (
             <AnimatedIcon
               key={i}

--- a/src/StarRatingDisplay.tsx
+++ b/src/StarRatingDisplay.tsx
@@ -55,11 +55,11 @@ type Props = {
   StarIconComponent?: (props: StarIconProps) => JSX.Element;
 
   /**
-   * Enable quarter star ratings.
+   * Step size for the rating.
    *
-   * @default false
+   * @default 'half'
    */
-  enableQuarterStar?: boolean;
+  step?: 'half' | 'quarter' | 'full';
 
   /**
    * The accessibility label used on the star component.
@@ -78,7 +78,7 @@ const StarRatingDisplay = ({
   starSize = 32,
   color = defaultColor,
   emptyColor = color,
-  enableQuarterStar = false,
+  step = 'half',
   style,
   starStyle,
   StarIconComponent = StarIcon,
@@ -91,7 +91,7 @@ const StarRatingDisplay = ({
       accessibilityLabel={accessibilityLabel}
       testID={testID}
     >
-      {getStars(rating, maxStars, enableQuarterStar).map((starType, i) => {
+      {getStars(rating, maxStars, step).map((starType, i) => {
         return (
           <View key={i} style={[styles.star, starStyle]}>
             <StarIconComponent

--- a/src/StarRatingDisplay.tsx
+++ b/src/StarRatingDisplay.tsx
@@ -55,6 +55,13 @@ type Props = {
   StarIconComponent?: (props: StarIconProps) => JSX.Element;
 
   /**
+   * Enable quarter star ratings.
+   *
+   * @default false
+   */
+  enableQuarterStar?: boolean;
+
+  /**
    * The accessibility label used on the star component.
    *
    * @default `star rating. ${rating} stars.`
@@ -71,6 +78,7 @@ const StarRatingDisplay = ({
   starSize = 32,
   color = defaultColor,
   emptyColor = color,
+  enableQuarterStar = false,
   style,
   starStyle,
   StarIconComponent = StarIcon,
@@ -83,7 +91,7 @@ const StarRatingDisplay = ({
       accessibilityLabel={accessibilityLabel}
       testID={testID}
     >
-      {getStars(rating, maxStars).map((starType, i) => {
+      {getStars(rating, maxStars, enableQuarterStar).map((starType, i) => {
         return (
           <View key={i} style={[styles.star, starStyle]}>
             <StarIconComponent

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,27 @@
-export function getStars(rating: number, maxStars: number) {
+export function getStars(rating: number, maxStars: number, enableQuarterStar?: boolean) {
   return [...Array(maxStars)].map((_, i) => {
-    if (rating - i >= 1) {
+    const remainder = rating - i;
+    
+    if (remainder >= 1) {
       return 'full';
     }
-
-    return rating - i >= 0.5 ? 'half' : 'empty';
+    
+    if (enableQuarterStar) {
+      if (remainder >= 0.75) {
+        return 'three-quarter';
+      }
+      if (remainder >= 0.5) {
+        return 'half';
+      }
+      if (remainder >= 0.25) {
+        return 'quarter';
+      }
+    } else {
+      if (remainder >= 0.5) {
+        return 'half';
+      }
+    }
+    
+    return 'empty';
   });
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,27 +1,21 @@
-export function getStars(rating: number, maxStars: number, enableQuarterStar?: boolean) {
+export function getStars(
+  rating: number,
+  maxStars: number,
+  step?: 'half' | 'quarter' | 'full'
+) {
   return [...Array(maxStars)].map((_, i) => {
     const remainder = rating - i;
-    
-    if (remainder >= 1) {
-      return 'full';
+
+    if (remainder >= 1) return 'full';
+
+    if (step === 'quarter') {
+      if (remainder >= 0.75) return 'three-quarter';
+      if (remainder >= 0.5) return 'half';
+      if (remainder >= 0.25) return 'quarter';
+    } else if (step === 'half') {
+      if (remainder >= 0.5) return 'half';
     }
-    
-    if (enableQuarterStar) {
-      if (remainder >= 0.75) {
-        return 'three-quarter';
-      }
-      if (remainder >= 0.5) {
-        return 'half';
-      }
-      if (remainder >= 0.25) {
-        return 'quarter';
-      }
-    } else {
-      if (remainder >= 0.5) {
-        return 'half';
-      }
-    }
-    
+
     return 'empty';
   });
 }


### PR DESCRIPTION
- Add StarQuarter (33% fill) and StarThreeQuarter (66% fill) components
- Refactor all star components to use consistent LinearGradient approach
- Add enableQuarterStar prop to StarRating and StarRatingDisplay
- Update getStars utility function to handle quarter star logic
- Maintain backward compatibility (enableQuarterStar defaults to false)

This allows users to display more granular ratings with 0.25 step increments (0, 0.25, 0.5, 0.75, 1.0, etc.)